### PR TITLE
ypbind/autofs: better handling of startup

### DIFF
--- a/sv/autofs/run
+++ b/sv/autofs/run
@@ -1,11 +1,16 @@
 #!/bin/sh
 
+exec 2>&1
+
 test -f /etc/default/autofs && . /etc/default/autofs
 test -f /etc/sysconfig/autofs && . /etc/sysconfig/autofs
 test -n "$TIMEOUT" && daemonoptions="--timeout=$TIMEOUT $daemonoptions"
 
-# Check if NIS is up. If it's not installed, this will fail,
-# and run automount anyway to handle non-NIS based maps.
-sv check ypbind
+# Check if NIS is up. If it's not installed, this will fail but
+# then start the automounter anyway.
+if sv up ypbind ; then
+	sv check ypbind &&
+	test -n "$(ypwhich)" || (echo "waiting for ypbind" && exit 1)
+fi
 
 exec /usr/sbin/automount -f $daemonoptions >/dev/null 2>&1

--- a/sv/ypbind/check
+++ b/sv/ypbind/check
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-timeout 1 ypwhich
+ypwhich


### PR DESCRIPTION
./check only gets run if the target service is up or requested to
be up. At start of day that might not be the case if ypbind has
not been started at all. Handle that by looking to see if
ypwhich returns anything sensible.
