### PR TITLE
Fix some shell errors in run-socklog

### DIFF
--- a/sv/.log/run-socklog
+++ b/sv/.log/run-socklog
@@ -20,10 +20,13 @@ SVNAME=$( basename $( echo `pwd` | sed 's/log//' ) )
 LOGMODE=$(echo $SVNAME | sed 's/-/ /' | awk '{ print $2 }' )
 
 # assign a sensical default
-case $LOGMODE
+case $LOGMODE in
   unix) LOGARGS="/dev/log"
+    ;;
   inet) LOGARGS="127.0.0.1 514"
+    ;;
   ucspi) LOGARGS=""
+    ;;
 esac
 [ -f ./options ] && . ./options]
 exec /usr/bin/socklog $LOGMODE $LOGARGS


### PR DESCRIPTION
This fixes a few small errors in the run-socklog shell script, discovered by dpkg-buildpackage.
