### PR TITLE
needs.sh: use relative service directory for dependency check

### DIFF
--- a/svcdef/.run/needs.sh
+++ b/svcdef/.run/needs.sh
@@ -15,16 +15,14 @@
         # the directory really exists, as it is possible for
         # the ./needs to be present but no entry present in /service
         if test -h $SVCITER ; then
-          echo -n "$SVCNAME, "
-          $DO_UP $SVCNAME
-          if test $? -eq 0 ; then
-            $DO_CHECK $SVCNAME
-            if test $? -gt 0 ; then
+          echo -n "$SVCITER, "
+          if $DO_UP $SVCITER ; then
+            if $DO_CHECK $SVCITER ; then
+             echo "$SVCNAME up."
+            else
               # a needed dependency failed, write the error out
               echo "$SVCNAME failed to start, aborting."
               exit 1
-            else
-             echo "$SVCNAME up."
             fi
           else
             echo "$SVCNAME did not come up successfully, aborting."

--- a/svcdef/.run/needs.sh
+++ b/svcdef/.run/needs.sh
@@ -18,7 +18,7 @@
           echo -n "$SVCITER, "
           if $DO_UP $SVCITER ; then
             if $DO_CHECK $SVCITER ; then
-             echo "$SVCNAME up."
+              echo "$SVCNAME up."
             else
               # a needed dependency failed, write the error out
               echo "$SVCNAME failed to start, aborting."

--- a/svcdef/.run/run-user-service.sh
+++ b/svcdef/.run/run-user-service.sh
@@ -10,7 +10,7 @@
 #   /service/(framework name)-(user name)
 #
 # REQUIREMENTS:
-#  (framework name) is one of  "svscan", "rundirsv", or "s6-svscan".  No other options are valid
+#  (framework name) is one of  "svscan", "runsvdir", or "s6-svscan".  No other options are valid
 #  (user name) is a valid local account name without quotes, i.e. user name 'jdoe' for user "Jane Doe"
 #
 # EXAMPLES:


### PR DESCRIPTION
This allows full use of the _needs.sh_ dependency check (brilliant idea btw).

Now service directory is checked rather than service name, which means
that it works with any service directory like `/var/service`,
instead of just `/service`.